### PR TITLE
Fix scripts when there is only one connection

### DIFF
--- a/src/scripts/get_connections.applescript
+++ b/src/scripts/get_connections.applescript
@@ -6,7 +6,7 @@ on join_list(the_list, delimiter)
 	set old_delims to AppleScript's text item delimiters
 	repeat with the_item in the_list
 		if the_string is equal to "" then
-			set the_string to the_item
+			set the_string to the_string & the_item
 		else
 			set the_string to the_string & delimiter & the_item
 		end if


### PR DESCRIPTION
With only 1 connection, the AppleScript was getting `item 1 of {"{name}
{status}"}` instead of just the string. This would prevent
connect/disconnect from working as the extra "item 1" prefix gets tacked
on everywhere. Here we just coerce that initial value into a string type
so it continues to behave as expected.

p.s. Great project! I use it everyday and love it. :smile: :+1: 